### PR TITLE
Dynamic icons based on file-icons

### DIFF
--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -4,6 +4,7 @@ import { el, mount, setAttr } from 'redom';
 import format from 'date-fns/format';
 import map from 'lodash/map';
 import isGithubUrl from 'is-github-url'
+import isGitlabUrl from 'is-gitlab-url'
 
 import { calculatePixelsFromLine } from '../helpers/atom';
 
@@ -65,9 +66,17 @@ const addWebsiteLink = (data) => {
     return undefined;
   }
 
+  let iconClass = 'icon icon-globe'
+
+  if(isGithubUrl(data.homepage)) {
+    iconClass += ' github-icon'
+  } else if (isGitlabUrl(data.homepage)) {
+    iconClass = ' gitlab-icon'
+  }
+
   const icon = el('i');
   setAttr(icon, {
-    className: isGithubUrl(data.homepage) ? 'icon icon-globe github-icon' : 'icon icon-globe',
+    className: iconClass,
   });
 
   const homepage = el('a', icon);

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -3,6 +3,7 @@
 import { el, mount, setAttr } from 'redom';
 import format from 'date-fns/format';
 import map from 'lodash/map';
+import isGithubUrl from 'is-github-url'
 
 import { calculatePixelsFromLine } from '../helpers/atom';
 
@@ -66,7 +67,7 @@ const addWebsiteLink = (data) => {
 
   const icon = el('i');
   setAttr(icon, {
-    className: 'icon icon-globe',
+    className: isGithubUrl(data.homepage) ? 'icon icon-globe github-icon' : 'icon icon-globe',
   });
 
   const homepage = el('a', icon);
@@ -87,7 +88,7 @@ const addNpmLink = (data) => {
 
   const icon = el('i');
   setAttr(icon, {
-    className: 'icon icon-repo',
+    className: 'icon icon-repo npm-icon',
   });
 
   const npm = el('a', icon);

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -12,6 +12,7 @@ import {
   TOOLTIP,
   DATE_FORMAT,
   MIN_HEIGHT,
+  ICON_CLASSES,
 } from '../constants/elements';
 
 export const removeTooltip = (element, data) => {
@@ -50,6 +51,18 @@ const addReleaseDate = (data) => {
   );
 };
 
+const getRepoIcon = (homepage, iconClass = ICON_CLASSES) => {
+  if (isGithubUrl(homepage)) {
+    return `${iconClass} github-icon`;
+  }
+
+  if (isGitlabUrl(homepage)) {
+    return `${iconClass} gitlab-icon`;
+  }
+
+  return iconClass;
+};
+
 const addAuthor = (data) => {
   if (!data || !data.author || !data.author.name) {
     return undefined;
@@ -66,17 +79,9 @@ const addWebsiteLink = (data) => {
     return undefined;
   }
 
-  let iconClass = 'icon icon-globe'
-
-  if(isGithubUrl(data.homepage)) {
-    iconClass += ' github-icon'
-  } else if (isGitlabUrl(data.homepage)) {
-    iconClass = ' gitlab-icon'
-  }
-
   const icon = el('i');
   setAttr(icon, {
-    className: iconClass,
+    className: getRepoIcon(data.homepage),
   });
 
   const homepage = el('a', icon);

--- a/lib/constants/elements.js
+++ b/lib/constants/elements.js
@@ -5,3 +5,4 @@ export const BADGE = `${NPM_LIBRARY_DESCRIPTION}-badge`;
 export const TOOLTIP = 'npm-library-tooltip';
 export const DATE_FORMAT = 'MMMM Do, YYYY ';
 export const MIN_HEIGHT = 200;
+export const ICON_CLASSES = 'icon icon-globe';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "axios": "^0.17.1",
     "date-fns": "^1.29.0",
+    "is-github-url": "^1.2.2",
     "is-json": "^2.0.1",
     "lodash": "^4.17.4",
     "redom": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "axios": "^0.17.1",
     "date-fns": "^1.29.0",
     "is-github-url": "^1.2.2",
+    "is-gitlab-url": "^1.0.0",
     "is-json": "^2.0.1",
     "lodash": "^4.17.4",
     "redom": "^3.7.0",


### PR DESCRIPTION
Hello @victorhqc 
Just a little something I felt it was missing since I didn't really love the default icon set.
Assuming that the user have installed [this](https://atom.io/packages/file-icons) pretty famous package now the icons will look like:

| Github | Gitlab | Otherwise |
|--|--|--|
| <img width="206" alt="github-final" src="https://user-images.githubusercontent.com/6209647/38802707-82537742-416d-11e8-90a1-7433d36e61ef.png"> | <img width="225" alt="gitlab-final" src="https://user-images.githubusercontent.com/6209647/38802709-828653c4-416d-11e8-9b1f-60a7516a6eb1.png"> | <img width="211" alt="base-final" src="https://user-images.githubusercontent.com/6209647/38802706-822f8756-416d-11e8-8b14-cd1f632cdb8c.png"> |

And they will change according to the module homepage url.
In case ```file-icons``` is not installed or disabled the current look will remain untouched.