### PR TITLE
Open folder in atom

### DIFF
--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -159,7 +159,7 @@ const addAtomLink = (data) => {
   });
 
   if (existDirlink)
-     atom_el.addEventListener('click', ()=>{
+    atom_el.addEventListener('click', () => {
       atom.project.addPath(dirlink.getPath())
     });
 

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -147,7 +147,12 @@ const addAtomLink = (data) => {
     className: 'icon icon-repo atom-icon',
   });
 
-  const atom_el = el('a', icon);
+  const iconWrapper = el('span', icon);
+  setAttr(iconWrapper, {
+    className: 'tab selected',
+  });
+
+  const atom_el = el('a', iconWrapper);
   setAttr(atom_el, {
     className: 'btn' + (existDirlink ? '' : ' btn-disabled'),
     title: data.name,

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -3,8 +3,15 @@
 import { el, mount, setAttr } from 'redom';
 import format from 'date-fns/format';
 import map from 'lodash/map';
-import isGithubUrl from 'is-github-url';
-import isGitlabUrl from 'is-gitlab-url';
+import isGithubUrl from 'is-github-url'
+import isGitlabUrl from 'is-gitlab-url'
+import {Directory, File} from 'atom'
+
+import {
+  getView,
+  getEditorKey,
+  getActiveTextEditor,
+} from '../helpers/atom';
 
 import { calculatePixelsFromLine } from '../helpers/atom';
 
@@ -127,6 +134,33 @@ const addNpmLink = (data) => {
   return npm;
 };
 
+const addAtomLink = (data) => {
+  if (!data || !data.name) {
+    return undefined;
+  }
+
+  const dirlink = new Directory(atom.workspace.getActiveTextEditor().buffer.file.getParent().path+"/node_modules/"+data.name)
+  const existDirlink = dirlink.existsSync()
+
+  const icon = el('i');
+  setAttr(icon, {
+    className: 'icon icon-repo atom-icon',
+  });
+
+  const atom_el = el('a', icon);
+  setAttr(atom_el, {
+    className: 'btn' + (existDirlink ? '' : ' btn-disabled'),
+    title: data.name,
+  });
+
+  if (existDirlink)
+     atom_el.addEventListener('click', ()=>{
+      atom.project.addPath(dirlink.getPath())
+    });
+
+  return atom_el;
+};
+
 // Checks if the tooltip should be opened up or down depending on the badge's position relative to
 // the screen.
 const shouldOpenOnBottom = pixelsToBottom => pixelsToBottom >= MIN_HEIGHT;
@@ -144,6 +178,7 @@ const addFooter = (data) => {
 
   const footer = el('footer',
     infoContainer,
+    addAtomLink(data),
     addWebsiteLink(data),
     addNpmLink(data),
   );

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -5,7 +5,7 @@ import format from 'date-fns/format';
 import map from 'lodash/map';
 import isGithubUrl from 'is-github-url'
 import isGitlabUrl from 'is-gitlab-url'
-import {Directory, File} from 'atom'
+import { Directory } from 'atom'
 
 import {
   getView,

--- a/lib/components/tooltip.js
+++ b/lib/components/tooltip.js
@@ -144,7 +144,7 @@ const addAtomLink = (data) => {
 
   const icon = el('i');
   setAttr(icon, {
-    className: 'icon icon-repo atom-icon',
+    className: 'icon icon-file-directory atom-icon',
   });
 
   const iconWrapper = el('span', icon);

--- a/styles/npm-library-description.less
+++ b/styles/npm-library-description.less
@@ -98,7 +98,7 @@
       &:hover {
         color: #9da5b4;
         background-image: linear-gradient(#3a3f4b, #353b45);
-        cursor: default;
+        cursor: not-allowed;
       }
     }
 

--- a/styles/npm-library-description.less
+++ b/styles/npm-library-description.less
@@ -93,6 +93,15 @@
         }
       }
     }
+
+    .btn-disabled {
+      &:hover {
+        color: #9da5b4;
+        background-image: linear-gradient(#3a3f4b, #353b45);
+        cursor: default;
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
It sometimes happens that I need to quickly look into a dependency code, or tweak it to see how it works and of course for debug purposes.

So this PR add a utility button to add the selected module folder in the tree view.
If the dependencies are not installed, the button is clearly unclickable.

With file-icons:
<img width="237" alt="schermata 2018-04-18 alle 13 19 54" src="https://user-images.githubusercontent.com/6209647/38929009-47e1487e-430b-11e8-9318-dbb0a13cfb80.png">

Without:
<img width="247" alt="schermata 2018-04-18 alle 13 18 57" src="https://user-images.githubusercontent.com/6209647/38929010-47ff2718-430b-11e8-9498-b8fc5d05b99a.png">
