### PR TITLE
Avoids missplaced badges.

### DIFF
--- a/lib/helpers/dependencies.js
+++ b/lib/helpers/dependencies.js
@@ -26,8 +26,8 @@ export const mapDependenciesFromJson = json => ({
   devDependencies: mapDependencies(json.devDependencies),
 });
 
-export const doesTextMatchDependency = text => dependency =>
-  text.match(new RegExp(`"${dependency}":`));
+export const doesTextMatchJSONKey = text => string =>
+  text.match(new RegExp(`"${string}":`));
 
 export const readDependenciesFromJson = (json, { textEditor, store, preferences }) => {
   const {
@@ -36,10 +36,31 @@ export const readDependenciesFromJson = (json, { textEditor, store, preferences 
   } = mapDependenciesFromJson(json);
 
   const lines = textEditor.getLineCount();
-  for (let line = 0; line < lines; line += 1) {
+  // Used to avoid filling dependency marker in wrong place.
+  // Only if dependency is in `dependencies` or `devDependencies`. should be marked.
+  let validLine = false;
+  Array.from(Array(lines).keys()).forEach((line) => {
     const text = textEditor.lineTextForBufferRow(line);
-    const dependency = find(dependencies, doesTextMatchDependency(text));
-    const devDependency = find(devDependencies, doesTextMatchDependency(text));
+
+    const isDependency = doesTextMatchJSONKey(text)('dependencies');
+    const isDevDependency = doesTextMatchJSONKey(text)('devDependencies');
+
+    if (isDependency || isDevDependency) {
+      validLine = true;
+    }
+
+    // Ends dependencies or devDependencies block
+    if (validLine && text.match(/\}$/gi)) {
+      validLine = false;
+    }
+
+    // Don't add a marker if is not a valid line.
+    if (!validLine) {
+      return;
+    }
+
+    const dependency = find(dependencies, doesTextMatchJSONKey(text));
+    const devDependency = find(devDependencies, doesTextMatchJSONKey(text));
 
     if (dependency || devDependency) {
       store.dispatch(addDependency({
@@ -49,5 +70,5 @@ export const readDependenciesFromJson = (json, { textEditor, store, preferences 
         textEditorKey: getEditorKey(textEditor),
       }));
     }
-  }
+  });
 };


### PR DESCRIPTION
When a dependency name appeared somewhere in the package.json and 
outside the dependencies or devDependencies block. An information badge 
was rendered. But that was a bug, there should not be an information 
badge outside the dependencies block.